### PR TITLE
Add flutter_peer package to the contributions list

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -41,3 +41,4 @@ Please add your package at the end of the table:
 | df_tooltip | https://pub.dev/packages/df_tooltip | https://fluttergems.dev/layout-overlay/|
 | flutter_multi_dialogs | https://pub.dev/packages/flutter_multi_dialogs | https://fluttergems.dev/dialogs/ |
 | maintenance_banner | https://pub.dev/packages/maintenance_banner | https://fluttergems.dev/badge/ |
+| flutter_peer | https://pub.dev/packages/flutter_peer | https://fluttergems.dev/real-time-communication |


### PR DESCRIPTION
**Summary:** 
Adds a single row to the Packages table in CONTRIB.md to list the flutter_peer package and its suggested category.

**Motivation:** 
Make flutter_peer discoverable in the curated package list and suggest its category for site organization.
Change: Inserted the following table row into the end of the Packages table:
`| flutter_peer | https://pub.dev/packages/flutter_peer | https://fluttergems.dev/real-time-communication |`

**Testing**

File: Verify the new row appears in [CONTRIB.md](https://ideal-funicular-q7976w4vr5r4cx66r.github.dev/).
Links: Click both URLs to confirm they resolve and point to the correct package/category.
Formatting: Confirm table renders correctly on GitHub/GitLab (no broken pipes or alignment issues).
Reviewer Checklist

**URLs:** Pub.dev and category URLs are correct and reachable.
**Category:** Suggested category (real-time-communication) is appropriate.
**Formatting:** Row matches existing table style and uses proper Markdown pipes.
**Typos:** No spelling or grammar issues in the entry.