### PR TITLE
Add loam

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -148,3 +148,4 @@ Please add your package at the end of the table:
 | moarch | https://pub.dev/packages/moarch | https://fluttergems.dev/flutter-framework/ |
 | auth_uae_pass | https://pub.dev/packages/auth_uae_pass | https://fluttergems.dev/cryptography-security-permissions/ |
 | thai_address_plus | https://pub.dev/packages/thai_address_plus | https://fluttergems.dev/location-place-address-picker/ |
+| loam | https://pub.dev/packages/loam | https://fluttergems.dev/developer-tools/ |


### PR DESCRIPTION
Adds loam to the package list under developer-tools (https://fluttergems.dev/developer-tools/).