### PR TITLE
Add 6 packages by jayu1023

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -148,3 +148,9 @@ Please add your package at the end of the table:
 | moarch | https://pub.dev/packages/moarch | https://fluttergems.dev/flutter-framework/ |
 | auth_uae_pass | https://pub.dev/packages/auth_uae_pass | https://fluttergems.dev/cryptography-security-permissions/ |
 | thai_address_plus | https://pub.dev/packages/thai_address_plus | https://fluttergems.dev/location-place-address-picker/ |
+| streamdown | https://pub.dev/packages/streamdown |  |
+| paywall_kit | https://pub.dev/packages/paywall_kit |  |
+| llm_meter | https://pub.dev/packages/llm_meter |  |
+| agent_kit | https://pub.dev/packages/agent_kit |  |
+| liquid_glass_hig | https://pub.dev/packages/liquid_glass_hig |  |
+| flutter_lighthouse | https://pub.dev/packages/flutter_lighthouse |  |


### PR DESCRIPTION
Adding 6 published Dart/Flutter packages to Flutter Gems:

- streamdown — streaming Markdown renderer for AI apps — https://pub.dev/packages/streamdown
- paywall_kit — prebuilt paywall variants — https://pub.dev/packages/paywall_kit
- llm_meter — LLM token & cost metering — https://pub.dev/packages/llm_meter
- agent_kit — AI agent UI components — https://pub.dev/packages/agent_kit
- liquid_glass_hig — iOS 26 Liquid Glass UI primitives — https://pub.dev/packages/liquid_glass_hig
- flutter_lighthouse — one-tap performance audit (0–100 score + findings) — https://pub.dev/packages/flutter_lighthouse

Category column left blank (optional) — happy to fill in suggested categories if preferred.