### PR TITLE
Add audio_stream_player

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -195,3 +195,4 @@ Please add your package at the end of the table:
 | flutter_storage_inspector | https://pub.dev/packages/flutter_storage_inspector | https://fluttergems.dev/developer-tools/ |
 | admob_flutter_plus | https://pub.dev/packages/admob_flutter_plus | https://fluttergems.dev/ad-serving/ |
 | liquid_drop_nav_bar | https://pub.dev/packages/liquid_drop_nav_bar | https://fluttergems.dev/bottom-navigation-bar/ |
+| audio_stream_player | https://pub.dev/packages/audio_stream_player | https://fluttergems.dev/audio/ |


### PR DESCRIPTION
Adds [audio_stream_player](https://pub.dev/packages/audio_stream_player) — a low-latency raw PCM streaming player for feeding audio chunks from TTS and realtime voice APIs (Android/iOS/macOS). Suggested category: Audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2mH46XZhvsZvcRCJyCytE