### PR TITLE
Add flutter_classic_bluetooth package

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -195,3 +195,4 @@ Please add your package at the end of the table:
 | flutter_storage_inspector | https://pub.dev/packages/flutter_storage_inspector | https://fluttergems.dev/developer-tools/ |
 | admob_flutter_plus | https://pub.dev/packages/admob_flutter_plus | https://fluttergems.dev/ad-serving/ |
 | liquid_drop_nav_bar | https://pub.dev/packages/liquid_drop_nav_bar | https://fluttergems.dev/bottom-navigation-bar/ |
+| flutter_classic_bluetooth | https://pub.dev/packages/flutter_classic_bluetooth | https://fluttergems.dev/bluetooth-nfc-beacon/ |


### PR DESCRIPTION
@
Adding `flutter_classic_bluetooth` to the contribution list.

- pub.dev: https://pub.dev/packages/flutter_classic_bluetooth
- Repo: https://github.com/almasumdev/flutter_classic_bluetooth
- Suggested category: https://fluttergems.dev/bluetooth-nfc-beacon/

Bluetooth Classic (RFCOMM/SPP) serial plugin. Device discovery, pairing, client and server sockets, and byte streams over a single Dart API on Android, Windows, macOS, Linux and iOS (MFi). 160/160 pub points, MIT licensed, published under a verified publisher.
@