### PR TITLE
Add virtual_keypad to the Keyboard category

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -195,3 +195,4 @@ Please add your package at the end of the table:
 | flutter_storage_inspector | https://pub.dev/packages/flutter_storage_inspector | https://fluttergems.dev/developer-tools/ |
 | admob_flutter_plus | https://pub.dev/packages/admob_flutter_plus | https://fluttergems.dev/ad-serving/ |
 | liquid_drop_nav_bar | https://pub.dev/packages/liquid_drop_nav_bar | https://fluttergems.dev/bottom-navigation-bar/ |
+| virtual_keypad | https://pub.dev/packages/virtual_keypad | https://fluttergems.dev/keyboard/ |


### PR DESCRIPTION
Adding `virtual_keypad` to the Keyboard category.

| Package Name | pub dev URL | Suggested Category |
| --- | --- | --- |
| virtual_keypad | https://pub.dev/packages/virtual_keypad | https://fluttergems.dev/keyboard/ |

**What it is:** an on-screen keyboard widget you draw inside your own app, for cases where the system keyboard is missing, blocked, or not enough — kiosk and POS terminals, ATM and PIN entry, touchscreen and desktop apps, and Android TV boxes driven by a D-pad remote.

**What is a bit different from the existing keyboard entries:**

- Drops into any stock `TextField` / `TextFormField` with `standalone: true`, so no controller swap or wrapper widget is needed
- 12 built-in language layouts including Arabic RTL, Bengali, Devanagari, Hangul, Thai, and Cyrillic, switchable at runtime
- D-pad and remote navigation for Android TV, Fire TV, and set-top boxes
- Custom layouts for PIN pads, OTP entry, and numeric keypads
- Draggable floating panel mode with persistent visibility for kiosk screens
- Emoji render offline on Flutter web from a bundled subset font, with optional runtime color font loading
- Pure Dart and Flutter widgets, no native code or platform channels

MIT licensed, 160/160 pub points, Android, iOS, Web, Windows, macOS, and Linux.